### PR TITLE
Set up GitHub actions for build and publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/* @DOI-BOR/bdo-wtmp
+.github/workflows/* @DOI-BOR/bdo-wtmp

--- a/.github/workflows/publish_build.yml
+++ b/.github/workflows/publish_build.yml
@@ -1,0 +1,33 @@
+name: Publish with Gradle
+
+permissions:
+  contents: read
+  packages: write  
+
+# this should only be triggered manually
+on: workflow_dispatch
+
+jobs:
+  build:
+    # run on windows to mimic local build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        # checkout action hash for version 6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Java
+        # setup-java action hash for version 5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          # Gradle needs java 17 or above
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Publish with Gradle wrapper command
+        # this run will do the publishing with the wrapper already provided in the repository
+        run: ./gradlew.bat publish
+        # these are the credentials we will need
+        env:
+            GITHUB_ACTOR: ${{ secrets.PACKAGES_USER }}
+            GITHUB_TOKEN: ${{ secrets.PACKAGES_PAT }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,31 @@
+name: Test Build with Gradle
+
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+
+jobs:
+  build:
+    # run on windows to mimic local build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        # checkout action hash for version 6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Java
+        # setup-java action hash for version 5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          # Gradle needs java 17 or above
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle wrapper command
+        # this run will do the build with the wrapper already provided in the repository
+        run: ./gradlew.bat build

--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,16 @@ publishing {
             artifact source: tasks.named("zipJasper"), extension: 'zip'
         }
     }
+
+    // publish to github packages
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/DOI-BOR/WTMP-Jasper-Reporting")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Set up the GitHub actions for this repository. 

A build will automatically trigger when a push or merge request is made into main. There is also an action for publishing, but this must be manually triggered. Also added a CODEOWNERS files to comply with DOI requirements. 