### PR TITLE
Moved publishing repo location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,16 +35,4 @@ publishing {
             artifact source: tasks.named("zipJasper"), extension: 'zip'
         }
     }
-
-    // publish to github packages
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/DOI-BOR/WTMP-Jasper-Reporting")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
 }

--- a/buildSrc/src/main/groovy/wtmp.publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/wtmp.publishing-conventions.gradle
@@ -2,3 +2,16 @@ plugins {
     id "maven-publish"
 }
 
+publishing{
+// publish to github packages
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/DOI-BOR/WTMP-Jasper-Reporting")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Following Stephen's recommendation, I have moved the publishing location to the conventions file. This was previously in the build.gradle file. Stephen recommended moving it to the conventions, so the code is more reusable. This won't change functionality.
